### PR TITLE
Swapped RX with TX in setup_sensor of examples.

### DIFF
--- a/examples/MTK_MEGA/MTK_MEGA.ino
+++ b/examples/MTK_MEGA/MTK_MEGA.ino
@@ -41,7 +41,7 @@ void setup() {
   Serial.begin(115200);
 
   //setup the Sensor
-  mtk.setup_sensor(TX_num,RX_num,muxPins,raw_data,threshold);
+  mtk.setup_sensor(RX_num,TX_num,muxPins,raw_data,threshold);
 }
 
 void loop() {

--- a/examples/MTK_UNO/MTK_UNO.ino
+++ b/examples/MTK_UNO/MTK_UNO.ino
@@ -41,7 +41,7 @@ void setup() {
   Serial.begin(115200);
 
   //setup the Sensor
-  mtk.setup_sensor(TX_num,RX_num,muxPins,raw_data,threshold);
+  mtk.setup_sensor(RX_num,TX_num,muxPins,raw_data,threshold);
 }
 
 void loop() {


### PR DESCRIPTION
I fixed a mistake that values (TX and RX) of the method "setup sensor" were reversed in examples.